### PR TITLE
Fix backend JWT login and namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ $exampleAbsolute = "/../";
 // __DIR__ 會回傳當前檔案所在的目錄，這裡為 "backend/vendor"
 // '/../' 代表從 "vendor" 回到上一層 "backend"
 // 再加上 "app/Controllers/Product.php" 就可以正確定位到該檔案
+
+## Postman 測試教學
+1. 安裝並開啟 [Postman](https://www.postman.com/)。
+2. 新增一個 **POST** 請求，URL 指向後端 `index.php` 所在路徑，例如：
+   `http://localhost/backend/public/index.php?action=doLogin`。
+3. 在 `Body` 欄位選擇 `x-www-form-urlencoded`，填入 `email` 及 `password` 參數後送出請求。
+4. 成功後會收到包含 `token` 的 JSON 回應。接著可在其他受保護的路由於 `Headers` 新增 `Authorization: Bearer <token>` 進行測試。

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,4 @@
+dbHost = 'localhost'
+dbName = 'erp'
+dbUser = 'root'
+dbPassword = ''

--- a/backend/bootstrap/Main.php
+++ b/backend/bootstrap/Main.php
@@ -1,7 +1,21 @@
 <?php
-require_once __DIR__ . "/../vendor/autoload.php";
+require_once __DIR__ . '/../vendor/autoload.php';
+// autoload vendor\ namespace classes
+spl_autoload_register(function ($class) {
+    $prefix = 'vendor\\';
+    $baseDir = __DIR__ . '/../vendor/';
+    if (strncmp($prefix, $class, strlen($prefix)) === 0) {
+        $relativeClass = substr($class, strlen($prefix));
+        $file = $baseDir . $relativeClass . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+});
+
 use App\Middlewares\AuthMiddleware;
-use App\Router;
+use vendor\Router;
+use vendor\DB;
 
 class Main {
     static function run() {

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -10,7 +10,8 @@
     "psr-4": {
       "App\\": "app/",
       "App\\Middlewares\\": "app/Middlewares/",
-      "App\\Controllers\\": "app/Controllers/",
+      "App\\Controllers\\": "app/Controller/",
+      "vendor\\": "vendor/",
       "App\\Models\\": "app/Models/"
     }
   }

--- a/backend/vendor/Router.php
+++ b/backend/vendor/Router.php
@@ -15,7 +15,7 @@ namespace vendor;
     public function run($action){
         $class = $this->routeTable[$action]['class'];
         $method = $this->routeTable[$action]['method'];
-        $class = "Controllers\\" . $class;
+        $class = "App\Controllers\\" . $class;
         $controller = new $class();
         $response = $controller->$method();
         return $response;

--- a/backend/vendor/composer/autoload_psr4.php
+++ b/backend/vendor/composer/autoload_psr4.php
@@ -9,6 +9,7 @@ return array(
     'Firebase\\JWT\\' => array($vendorDir . '/firebase/php-jwt/src'),
     'App\\Models\\' => array($baseDir . '/app/Models'),
     'App\\Middlewares\\' => array($baseDir . '/app/Middlewares'),
-    'App\\Controllers\\' => array($baseDir . '/app/Controllers'),
+    'App\\Controllers\\' => array($baseDir . '/app/Controller'),
     'App\\' => array($baseDir . '/app'),
+    'vendor\\' => array($baseDir . '/vendor'),
 );

--- a/backend/vendor/composer/autoload_static.php
+++ b/backend/vendor/composer/autoload_static.php
@@ -11,12 +11,16 @@ class ComposerStaticInit20fad51902f91e7fd3039e016a6556b5
         array (
             'Firebase\\JWT\\' => 13,
         ),
-        'A' => 
+        'A' =>
         array (
             'App\\Models\\' => 11,
             'App\\Middlewares\\' => 16,
             'App\\Controllers\\' => 16,
             'App\\' => 4,
+        ),
+        'v' =>
+        array (
+            'vendor\\' => 7,
         ),
     );
 
@@ -33,13 +37,17 @@ class ComposerStaticInit20fad51902f91e7fd3039e016a6556b5
         array (
             0 => __DIR__ . '/../..' . '/app/Middlewares',
         ),
-        'App\\Controllers\\' => 
+        'App\\Controllers\\' =>
         array (
-            0 => __DIR__ . '/../..' . '/app/Controllers',
+            0 => __DIR__ . '/../..' . '/app/Controller',
         ),
-        'App\\' => 
+        'App\\' =>
         array (
             0 => __DIR__ . '/../..' . '/app',
+        ),
+        'vendor\\' =>
+        array (
+            0 => __DIR__ . '/../..' . '/vendor',
         ),
     );
 


### PR DESCRIPTION
## Summary
- adjust composer autoload mapping
- load vendor namespace classes in Main
- update Router to use App namespaces
- add missing .env file
- add Postman usage guide in README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465a7c4280832ca4c4cbc5112518da