### PR TITLE
Fix Employee controller namespace and model usage

### DIFF
--- a/backend/app/Controller/Employee.php
+++ b/backend/app/Controller/Employee.php
@@ -1,7 +1,9 @@
 <?php
-namespace Models;
-use Vendor\DB;
+namespace App\Controllers;
 
+use vendor\Controller;
+use vendor\DB;
+use App\Models\Employee as EmployeeModel;
 
 class Employee extends Controller
 {
@@ -27,12 +29,12 @@ class Employee extends Controller
         $address = $_POST['address'];
         $email = $_POST['email'];
         $phone = $_POST['phone'];
-        return $this->employeeModel->newUser($name, $password, $JoinDate,$address, $email, $phone);
+        return $this->employeeModel->newUser($name, $password, $JoinDate, $address, $email, $phone);
     }
 
     public function removeUser() {
-        $id = $_POST['name'];
-        return $this->em->removeUser($name);
+        $name = $_POST['name'];
+        return $this->employeeModel->removeUser($name);
     }
     public function updateUser() {
         $name = $_POST['name'];
@@ -41,7 +43,7 @@ class Employee extends Controller
         $address = $_POST['address'];
         $email = $_POST['email'];
         $phone = $_POST['phone'];
-        return $this->em->updateUser($name, $password, $JoinDate,$address, $email, $phone);
+        return $this->employeeModel->updateUser($name, $password, $JoinDate, $address, $email, $phone);
     }
 }
 

--- a/backend/app/Models/Employee.php
+++ b/backend/app/Models/Employee.php
@@ -1,5 +1,6 @@
 <?php
-namespace Models;
+namespace App\Models;
+
 use vendor\DB;
 
 class Employee


### PR DESCRIPTION
## Summary
- align Employee controller namespace with PSR-4 autoload rules
- reference the Employee model using `App\Models` namespace
- instantiate the model and call it via `$this->employeeModel`

## Testing
- `composer dump-autoload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848257d5ff0832ca1ef65f79f198296